### PR TITLE
Avoid infinite rerenders if defaultValue of form is passed not as a constant object..

### DIFF
--- a/frontend/src/helpers/form/react-hook-form-helper.ts
+++ b/frontend/src/helpers/form/react-hook-form-helper.ts
@@ -27,7 +27,7 @@ export function useResetFormWhenDataIsLoaded<
         keepDirtyValues: true,
       });
     }
-  }, [defaultValues]);
+  }, [superjson.stringify(defaultValues)]);
 }
 
 export function requiredRule() {


### PR DESCRIPTION
There could be a situation when we don't really want to pass the whole object into the form and the goal is to just operate with some particular field (i.e. we need to save the value of only one field outa 3 on edit action). 

So, the problem is that if we i.e. use defaultValue option like this: 

```
  const form = useAdvancedForm<SomeDto>(
    useCallback(async (data) => {
      await QueryFactory.SomeQuery.Client.doSomething(data);
    }, []),
    {
      defaultValues: {
        someField: someDefaultValue,
      },
    },
  );
```

It will lead to infinite rerenders because the object which is passed to defaultValues is always new (I suppose it has some unique obj.link or whatever). 
But if we do this: 
```
  const defaultValues = useMemo(() => ({
    someField: someDefaultValue,
  }), [])
  
  const form = useAdvancedForm<SomeDto>(
    useCallback(async (data) => {
      await QueryFactory.SomeQuery.Client.doSomething(data);
    }, []),
    {
      defaultValues: defaultValues,
    },
  );
```

Object will stay the same and we'll face no issue. 

Since this particular behavior is not really obvious and infinite rerendering problem is always a pain - I suggest to just stringify each incoming object to avoid possible wasting of time for investigation of some developer.