### PR TITLE
Introduce logging factory for EF in TestBase.

### DIFF
--- a/webapi/Docs/database.dgml
+++ b/webapi/Docs/database.dgml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <DirectedGraph GraphDirection="LeftToRight" xmlns="http://schemas.microsoft.com/vs/2009/dgml">
   <Nodes>
-<Node Id="IModel" Label="TemplateAppDbContext" ChangeTrackingStrategy="ChangeTrackingStrategy.Snapshot" PropertyAccessMode="PropertyAccessMode.Default" ProductVersion="7.0.0" Annotations="BaseTypeDiscoveryConvention:DerivedTypes: System.Collections.Generic.Dictionary`2[System.Type,System.Collections.Generic.List`1[Microsoft.EntityFrameworkCore.Metadata.IConventionEntityType]]
+<Node Id="IModel" Label="TemplateAppDbContext" ChangeTrackingStrategy="ChangeTrackingStrategy.Snapshot" PropertyAccessMode="PropertyAccessMode.Default" ProductVersion="7.0.5" Annotations="BaseTypeDiscoveryConvention:DerivedTypes: System.Collections.Generic.Dictionary`2[System.Type,System.Collections.Generic.List`1[Microsoft.EntityFrameworkCore.Metadata.IConventionEntityType]]
 Npgsql:Enum:product_type: undefined,auto,electronic,other
 Npgsql:ValueGenerationStrategy: IdentityByDefaultColumn
 Relational:MaxIdentifierLength: 63

--- a/webapi/Lib/Testing/MccSoft.Testing/TestBase.cs
+++ b/webapi/Lib/Testing/MccSoft.Testing/TestBase.cs
@@ -185,14 +185,9 @@ public abstract class TestBase<TDbContext> where TDbContext : DbContext
     {
         _databaseInitializer.UseProvider(builder, connectionString);
 
-        var factory = LoggerFactory.Create(loggingBuilder =>
-        {
-            loggingBuilder.ClearProviders().AddXUnit(OutputHelper);
-        });
-
         builder
             .WithLambdaInjection()
-            .UseLoggerFactory(factory)
+            .UseLoggerFactory(LoggerFactory.Create(ConfigureXunitLogger()))
             .EnableSensitiveDataLogging()
             .EnableDetailedErrors()
             .UseOpenIddict();
@@ -345,9 +340,7 @@ public abstract class TestBase<TDbContext> where TDbContext : DbContext
             _configuration = new ConfigurationBuilder().AddInMemoryCollection().Build()
         );
 
-        serviceCollection.AddLogging(
-            loggingBuilder => loggingBuilder.ClearProviders().AddXUnit(OutputHelper)
-        );
+        serviceCollection.AddLogging(ConfigureXunitLogger());
 
         serviceCollection.AddSingleton(configuration);
 
@@ -355,6 +348,11 @@ public abstract class TestBase<TDbContext> where TDbContext : DbContext
          * DO NOT register your project-specific services here!
          * Register your app-specific services in RegisterServices method
          */
+    }
+
+    private Action<ILoggingBuilder> ConfigureXunitLogger()
+    {
+        return loggingBuilder => loggingBuilder.ClearProviders().AddXUnit(OutputHelper);
     }
 
     protected virtual (ConfigurationBuilder, IWebHostEnvironment) SetupEnvironment()

--- a/webapi/Lib/Testing/MccSoft.Testing/TestBase.cs
+++ b/webapi/Lib/Testing/MccSoft.Testing/TestBase.cs
@@ -66,6 +66,7 @@ public abstract class TestBase<TDbContext> where TDbContext : DbContext
     protected readonly IDatabaseInitializer _databaseInitializer;
     protected Mock<IWebHostEnvironment> _webHostEnvironment;
     protected IConfigurationRoot _configuration;
+    private ILoggerFactory _factory;
 
     protected TestBase(ITestOutputHelper outputHelper, DatabaseType? databaseType)
     {
@@ -185,9 +186,14 @@ public abstract class TestBase<TDbContext> where TDbContext : DbContext
     {
         _databaseInitializer.UseProvider(builder, connectionString);
 
+        var factory = LoggerFactory.Create(l =>
+        {
+            l.ClearProviders().AddXUnit(OutputHelper);
+        });
+
         builder
             .WithLambdaInjection()
-            // .UseLoggerFactory(LoggerFactory)
+            .UseLoggerFactory(factory)
             .EnableSensitiveDataLogging()
             .EnableDetailedErrors()
             .UseOpenIddict();
@@ -275,6 +281,7 @@ public abstract class TestBase<TDbContext> where TDbContext : DbContext
         configureRegistrations?.Invoke(serviceCollection);
 
         _serviceProvider = serviceCollection.BuildServiceProvider();
+
         return _serviceProvider;
     }
 
@@ -344,7 +351,7 @@ public abstract class TestBase<TDbContext> where TDbContext : DbContext
             loggingBuilder => loggingBuilder.ClearProviders().AddXUnit(OutputHelper)
         );
 
-        serviceCollection.AddSingleton<IConfiguration>(configuration);
+        serviceCollection.AddSingleton(configuration);
 
         /*
          * DO NOT register your project-specific services here!

--- a/webapi/Lib/Testing/MccSoft.Testing/TestBase.cs
+++ b/webapi/Lib/Testing/MccSoft.Testing/TestBase.cs
@@ -66,7 +66,6 @@ public abstract class TestBase<TDbContext> where TDbContext : DbContext
     protected readonly IDatabaseInitializer _databaseInitializer;
     protected Mock<IWebHostEnvironment> _webHostEnvironment;
     protected IConfigurationRoot _configuration;
-    private ILoggerFactory _factory;
 
     protected TestBase(ITestOutputHelper outputHelper, DatabaseType? databaseType)
     {
@@ -281,7 +280,6 @@ public abstract class TestBase<TDbContext> where TDbContext : DbContext
         configureRegistrations?.Invoke(serviceCollection);
 
         _serviceProvider = serviceCollection.BuildServiceProvider();
-
         return _serviceProvider;
     }
 

--- a/webapi/Lib/Testing/MccSoft.Testing/TestBase.cs
+++ b/webapi/Lib/Testing/MccSoft.Testing/TestBase.cs
@@ -185,9 +185,9 @@ public abstract class TestBase<TDbContext> where TDbContext : DbContext
     {
         _databaseInitializer.UseProvider(builder, connectionString);
 
-        var factory = LoggerFactory.Create(l =>
+        var factory = LoggerFactory.Create(loggingBuilder =>
         {
-            l.ClearProviders().AddXUnit(OutputHelper);
+            loggingBuilder.ClearProviders().AddXUnit(OutputHelper);
         });
 
         builder


### PR DESCRIPTION
TestOutputHelper is used as resolveable logger in logger factory for EF Core, to allow query inspection in tests.