### PR TITLE
refactor: Use async initialization of tests

### DIFF
--- a/webapi/Lib/Logging/MccSoft.Logging/LogAttribute.cs
+++ b/webapi/Lib/Logging/MccSoft.Logging/LogAttribute.cs
@@ -60,7 +60,6 @@ public class LogAttribute : OverrideMethodAspect, IAspect<INamedType>
         }
     }
 
-    [Template]
     public override dynamic? OverrideMethod()
     {
         var logger = (ILogger)meta.This._logger;

--- a/webapi/Lib/Logging/MccSoft.Logging/MccSoft.Logging.csproj
+++ b/webapi/Lib/Logging/MccSoft.Logging/MccSoft.Logging.csproj
@@ -8,7 +8,7 @@
   <ItemGroup>
     <PackageReference Include="Destructurama.JsonNet" Version="2.0.0" />
     <PackageReference Include="IdentityModel" Version="6.1.0" />
-    <PackageReference Include="Metalama.Framework" Version="2023.0.115" />
+    <PackageReference Include="Metalama.Framework" Version="2023.3.8" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="7.0.0" />
     <PackageReference Include="Sentry.Serilog" Version="3.31.0" />
     <PackageReference Include="Serilog.AspNetCore" Version="7.0.0" />

--- a/webapi/Lib/Testing/MccSoft.Testing/MccSoft.Testing.csproj
+++ b/webapi/Lib/Testing/MccSoft.Testing/MccSoft.Testing.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
   <TargetFramework>net7.0</TargetFramework>
     <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\$(AssemblyName).xml</DocumentationFile>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/webapi/src/MccSoft.TemplateApp.App/MccSoft.TemplateApp.App.csproj
+++ b/webapi/src/MccSoft.TemplateApp.App/MccSoft.TemplateApp.App.csproj
@@ -41,7 +41,7 @@
   <ItemGroup>
     <PackageReference Include="Roslyn.Analyzers" Version="1.0.3.4" />
     <PackageReference Include="Vp.Roslyn.Analyzers.All" Version="1.0.0" />
-    <PackageReference Include="Metalama.Framework" Version="2023.0.115" />
+    <PackageReference Include="Metalama.Framework" Version="2023.3.8" />
     <PackageReference Include="Microsoft.AspNetCore.SpaProxy" Version="7.0.5" />
     <PackageReference Include="Audit.NET.Serilog" Version="21.0.0" />
     <PackageReference Include="Audit.NET.PostgreSql" Version="21.0.0" />

--- a/webapi/tests/MccSoft.TemplateApp.App.Tests/AssemblyInfo.cs
+++ b/webapi/tests/MccSoft.TemplateApp.App.Tests/AssemblyInfo.cs
@@ -1,1 +1,0 @@
-﻿[assembly: CollectionBehavior(MaxParallelThreads = 8)]

--- a/webapi/tests/MccSoft.TemplateApp.App.Tests/ProductServiceTests.cs
+++ b/webapi/tests/MccSoft.TemplateApp.App.Tests/ProductServiceTests.cs
@@ -9,11 +9,14 @@ using Microsoft.EntityFrameworkCore;
 
 namespace MccSoft.TemplateApp.App.Tests;
 
-public class ProductServiceTests : AppServiceTestBase
+public sealed class ProductServiceTests : AppServiceTestBase
 {
     public ProductServiceTests(ITestOutputHelper outputHelper)
-        : base(outputHelper, DatabaseType.Postgres)
+        : base(outputHelper, DatabaseType.Postgres) { }
+
+    public override async Task InitializeAsync()
     {
+        await base.InitializeAsync();
         Sut = CreateService<ProductService>();
     }
 

--- a/webapi/tests/MccSoft.TemplateApp.App.Tests/SignUrlHelperTests.cs
+++ b/webapi/tests/MccSoft.TemplateApp.App.Tests/SignUrlHelperTests.cs
@@ -1,12 +1,16 @@
 using System.Security.Claims;
+using System.Threading.Tasks;
 using MccSoft.WebApi.SignedUrl;
 
 namespace MccSoft.TemplateApp.App.Tests;
 
-public class SignUrlHelperTests : AppServiceTestBase
+public sealed class SignUrlHelperTests : AppServiceTestBase
 {
-    public SignUrlHelperTests(ITestOutputHelper outputHelper) : base(outputHelper, null)
+    public SignUrlHelperTests(ITestOutputHelper outputHelper) : base(outputHelper, null) { }
+
+    public override async Task InitializeAsync()
     {
+        await base.InitializeAsync();
         Sut = CreateService<SignUrlHelper>(x => x.AddSignUrl("fDmp1K2YveBbfDmpfDmp1K2YveBbfDmp"));
     }
 

--- a/webapi/tests/MccSoft.TemplateApp.App.Tests/TestApiServiceTests.cs
+++ b/webapi/tests/MccSoft.TemplateApp.App.Tests/TestApiServiceTests.cs
@@ -6,11 +6,14 @@ using MccSoft.TemplateApp.TestUtils.Factories;
 
 namespace MccSoft.TemplateApp.App.Tests;
 
-public class TestApiServiceTests : AppServiceTestBase
+public sealed class TestApiServiceTests : AppServiceTestBase
 {
     public TestApiServiceTests(ITestOutputHelper outputHelper)
-        : base(outputHelper, DatabaseType.Postgres)
+        : base(outputHelper, DatabaseType.Postgres) { }
+
+    public override async Task InitializeAsync()
     {
+        await base.InitializeAsync();
         Sut = CreateService<TestApiService>();
     }
 

--- a/webapi/tests/MccSoft.TemplateApp.ComponentTests/ProductControllerTests.cs
+++ b/webapi/tests/MccSoft.TemplateApp.ComponentTests/ProductControllerTests.cs
@@ -6,12 +6,15 @@ using Microsoft.EntityFrameworkCore;
 
 namespace MccSoft.TemplateApp.ComponentTests;
 
-public class ProductTests : ComponentTestBase
+public sealed class ProductTests : ComponentTestBase
 {
-    private readonly ProductClient _productClient;
+    private ProductClient _productClient;
 
-    public ProductTests(ITestOutputHelper outputHelper) : base(outputHelper)
+    public ProductTests(ITestOutputHelper outputHelper) : base(outputHelper) { }
+
+    public override async Task InitializeAsync()
     {
+        await base.InitializeAsync();
         _productClient = new ProductClient(Client);
     }
 

--- a/webapi/tests/MccSoft.TemplateApp.ComponentTests/Properties/AssemblyInfo.cs
+++ b/webapi/tests/MccSoft.TemplateApp.ComponentTests/Properties/AssemblyInfo.cs
@@ -1,1 +1,0 @@
-﻿[assembly: CollectionBehavior(MaxParallelThreads = 8)]


### PR DESCRIPTION
It solves a problem that tests run into deadlock if test collections are more than available threads