### PR TITLE
Add fix for hangfire mock in component tests.

### DIFF
--- a/webapi/tests/MccSoft.TemplateApp.ComponentTests/ComponentTestBase.cs
+++ b/webapi/tests/MccSoft.TemplateApp.ComponentTests/ComponentTestBase.cs
@@ -145,7 +145,9 @@ public class ComponentTestBase : TestBase<TemplateAppDbContext>, IDisposable
         // services.RemoveRegistration<TService>();
 
         services.AddSingleton(
-            (_backgroundJobClient = HangfireMock.CreateHangfireMock(() => _serviceProvider)).Object
+            (
+                _backgroundJobClient = HangfireMock.CreateHangfireMock(() => TestServer.Services)
+            ).Object
         );
     }
 


### PR DESCRIPTION
- Previously hangfire mock used private TestBase._serviceProvider which was only initialized in case of CreateService being called, however it is a rare case in ComponentTests, so it would be better to use TestServer.Services instead.