### PR TITLE
Add TooManyRequestsException and integrate throttling

### DIFF
--- a/webapi/Lib/LowLevelPrimitives/MccSoft.LowLevelPrimitives/Exceptions/TooManyRequestsException.cs
+++ b/webapi/Lib/LowLevelPrimitives/MccSoft.LowLevelPrimitives/Exceptions/TooManyRequestsException.cs
@@ -1,0 +1,30 @@
+using System;
+using Microsoft.AspNetCore.Http;
+
+namespace MccSoft.LowLevelPrimitives.Exceptions;
+
+/// <summary>
+/// Thrown when the client has sent too many requests in a given amount of time and the server should
+/// reply with 429.
+/// </summary>
+public sealed class TooManyRequestsException : WebApiBaseException
+{
+    public int? RetryAfterSeconds { get; }
+    public DateTime? LockedUntilUtc { get; }
+
+    public TooManyRequestsException(
+        string message,
+        int? retryAfterSeconds = null,
+        DateTime? lockedUntil = null
+    )
+        : base(
+            ErrorTypes.TooManyRequests,
+            "Too many requests.",
+            StatusCodes.Status429TooManyRequests,
+            message
+        )
+    {
+        RetryAfterSeconds = retryAfterSeconds;
+        LockedUntilUtc = lockedUntil;
+    }
+}

--- a/webapi/Lib/WebApi/MccSoft.WebApi/Middleware/ErrorHandlerMiddleware.cs
+++ b/webapi/Lib/WebApi/MccSoft.WebApi/Middleware/ErrorHandlerMiddleware.cs
@@ -137,6 +137,12 @@ public class ErrorHandlerMiddleware
             AddTraceId(httpContext, details);
         }
 
+        if (ex is TooManyRequestsException { RetryAfterSeconds: > 0 } tooManyRequestsException)
+        {
+            httpContext.Response.Headers.RetryAfter =
+                tooManyRequestsException.RetryAfterSeconds.Value.ToString();
+        }
+
         await ExecuteResult(httpContext, result);
     }
 }


### PR DESCRIPTION
•	Introduce TooManyRequestsException (429) with optional Retry-After
•	Handle Retry-After in ErrorHandlerMiddleware
•	Make ThrottleAttribute throw the exception (instead of executing an  obj result) to keep all error formatting in one place